### PR TITLE
Tweaks

### DIFF
--- a/Source/Samples/42_PBRMaterials/PBRMaterials.cpp
+++ b/Source/Samples/42_PBRMaterials/PBRMaterials.cpp
@@ -120,6 +120,7 @@ void PBRMaterials::SetupViewport()
     SharedPtr<RenderPath> effectRenderPath = viewport->GetRenderPath()->Clone();
     effectRenderPath->Append(cache->GetResource<XMLFile>("PostProcess/BloomHDR.xml"));
     effectRenderPath->Append(cache->GetResource<XMLFile>("PostProcess/FXAA2.xml"));
+    effectRenderPath->Append(cache->GetResource<XMLFile>("PostProcess/GammaCorrection.xml"));
 
     viewport->SetRenderPath(effectRenderPath);
 }

--- a/Source/Samples/42_PBRMaterials/PBRMaterials.cpp
+++ b/Source/Samples/42_PBRMaterials/PBRMaterials.cpp
@@ -112,6 +112,8 @@ void PBRMaterials::SetupViewport()
     ResourceCache* cache = GetSubsystem<ResourceCache>();
     Renderer* renderer = GetSubsystem<Renderer>();
 
+    renderer->SetHDRRendering(true);
+
     // Set up a viewport to the Renderer subsystem so that the 3D scene can be seen
     SharedPtr<Viewport> viewport(new Viewport(context_, scene_, cameraNode_->GetComponent<Camera>()));
     renderer->SetViewport(0, viewport);

--- a/bin/Autoload/LargeData/Materials/PBR/Concrete.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Concrete.xml
@@ -4,8 +4,8 @@
 	<texture unit="diffuse" name="Textures/PBR/Concrete/Albedo.jpg" />
 	<texture unit="normal" name="Textures/PBR/Concrete/Normal.jpg" />
 	<texture unit="specular" name="Textures/PBR/Concrete/PBR.jpg" />
-	<parameter name="UOffset" value="1 0 0 0" />
-	<parameter name="VOffset" value="0 1 0 0" />
+	<parameter name="UOffset" value="0.5 0 0 0" />
+	<parameter name="VOffset" value="0 0.5 0 0" />
 	<parameter name="MatDiffColor" value="1 1 1 1" />
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />

--- a/bin/Autoload/LargeData/Materials/PBR/Tile.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Tile.xml
@@ -10,7 +10,7 @@
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
-	<parameter name="RoughnessPS" value="-0.4" />
+	<parameter name="RoughnessPS" value="0" />
 	<parameter name="MetallicPS" value="0" />
 	<cull value="ccw" />
 	<shadowcull value="ccw" />

--- a/bin/Autoload/LargeData/Materials/Skybox2.xml
+++ b/bin/Autoload/LargeData/Materials/Skybox2.xml
@@ -1,5 +1,18 @@
+<?xml version="1.0"?>
 <material>
-    <technique name="Techniques/DiffSkybox.xml" />
-    <texture unit="diffuse" name="Textures/Skybox2.xml" />
-    <cull value="none" />
+	<technique name="Techniques/DiffSkyboxHDRScale.xml" quality="0" loddistance="0" />
+	<texture unit="diffuse" name="Textures/Skybox2.xml" />
+	<parameter name="UOffset" value="1 0 0 0" />
+	<parameter name="VOffset" value="0 1 0 0" />
+	<parameter name="MatDiffColor" value="1 1 1 1" />
+	<parameter name="MatEmissiveColor" value="0 0 0" />
+	<parameter name="MatEnvMapColor" value="1 1 1" />
+	<parameter name="MatSpecColor" value="0 0 0 1" />
+	<parameter name="RoughnessPS" value="0.5" />
+	<parameter name="MetallicPS" value="0" />
+	<cull value="none" />
+	<shadowcull value="ccw" />
+	<fill value="solid" />
+	<depthbias constant="0" slopescaled="0" />
+	<renderorder value="128" />
 </material>

--- a/bin/Autoload/LargeData/Textures/PBR/Check/Albedo.xml
+++ b/bin/Autoload/LargeData/Textures/PBR/Check/Albedo.xml
@@ -1,0 +1,3 @@
+<texture>
+    <srgb enable="true" />
+</texture>

--- a/bin/Autoload/LargeData/Textures/PBR/DiamonPlate/Albedo.xml
+++ b/bin/Autoload/LargeData/Textures/PBR/DiamonPlate/Albedo.xml
@@ -1,0 +1,3 @@
+<texture>
+    <srgb enable="true" />
+</texture>

--- a/bin/Autoload/LargeData/Textures/PBR/HoverBike/Glass/Albedo.xml
+++ b/bin/Autoload/LargeData/Textures/PBR/HoverBike/Glass/Albedo.xml
@@ -1,0 +1,3 @@
+<texture>
+    <srgb enable="true" />
+</texture>

--- a/bin/Autoload/LargeData/Textures/PBR/HoverBike/Hull/Albedo.xml
+++ b/bin/Autoload/LargeData/Textures/PBR/HoverBike/Hull/Albedo.xml
@@ -1,0 +1,3 @@
+<texture>
+    <srgb enable="true" />
+</texture>

--- a/bin/Autoload/LargeData/Textures/PBR/Lead/Albedo.xml
+++ b/bin/Autoload/LargeData/Textures/PBR/Lead/Albedo.xml
@@ -1,0 +1,3 @@
+<texture>
+    <srgb enable="true" />
+</texture>

--- a/bin/Autoload/LargeData/Textures/PBR/Leather/Albedo.xml
+++ b/bin/Autoload/LargeData/Textures/PBR/Leather/Albedo.xml
@@ -1,0 +1,3 @@
+<texture>
+    <srgb enable="true" />
+</texture>

--- a/bin/Autoload/LargeData/Textures/PBR/Mud/Albedo.xml
+++ b/bin/Autoload/LargeData/Textures/PBR/Mud/Albedo.xml
@@ -1,0 +1,3 @@
+<texture>
+    <srgb enable="true" />
+</texture>

--- a/bin/Autoload/LargeData/Textures/PBR/Sand/Albedo.xml
+++ b/bin/Autoload/LargeData/Textures/PBR/Sand/Albedo.xml
@@ -1,0 +1,3 @@
+<texture>
+    <srgb enable="true" />
+</texture>

--- a/bin/CoreData/Shaders/GLSL/IBL.glsl
+++ b/bin/CoreData/Shaders/GLSL/IBL.glsl
@@ -267,13 +267,13 @@
         float mipSelect = roughness * 9.0;
 
         vec3 cube = textureLod(sZoneCubeMap, reflectVec, mipSelect).rgb;
-        vec3 cubeD = textureLod(sZoneCubeMap, reflectVec, 9.0).rgb;
+        vec3 cubeD = textureLod(sZoneCubeMap, wsNormal, 9.0).rgb;
         // Fake the HDR texture
         float brightness = clamp(cAmbientColor.a, 0.0, 1.0);
         float darknessCutoff = clamp((cAmbientColor.a - 1.0) * 0.1, 0.0, 0.25);
 
-        vec3 hdrCube = pow(cube + darknessCutoff, vec3(cAmbientColor.a));
-        vec3 hdrCubeD = pow(cubeD + darknessCutoff, vec3(cAmbientColor.a));
+        vec3 hdrCube = pow(cube + darknessCutoff, vec3(max(1.0, cAmbientColor.a)));
+        vec3 hdrCubeD = pow(cubeD + darknessCutoff, vec3(max(1.0, cAmbientColor.a * 0.5)));
 
         vec3 environmentSpecular = EnvBRDFApprox(specColor, roughness, ndv);
         vec3 environmentDiffuse = EnvBRDFApprox( diffColor * (1.0 - roughness), 1.0, ndv);

--- a/bin/CoreData/Shaders/GLSL/IBL.glsl
+++ b/bin/CoreData/Shaders/GLSL/IBL.glsl
@@ -269,12 +269,16 @@
         vec3 cube = textureLod(sZoneCubeMap, reflectVec, mipSelect).rgb;
         vec3 cubeD = textureLod(sZoneCubeMap, reflectVec, 9.0).rgb;
         // Fake the HDR texture
-        vec3 hdrCube = mix(cube, pow(cube + 0.25, vec3(6.0)), max(cAmbientColor.a, 0.0));
-        vec3 hdrCubeD = mix(cubeD, pow(cubeD + 0.25, vec3(3.0)), max(cAmbientColor.a, 0.0));
+        float brightness = clamp(cAmbientColor.a, 0.0, 1.0);
+        float darknessCutoff = clamp((cAmbientColor.a - 1.0) * 0.1, 0.0, 0.25);
+
+        vec3 hdrCube = pow(cube + darknessCutoff, vec3(cAmbientColor.a));
+        vec3 hdrCubeD = pow(cubeD + darknessCutoff, vec3(cAmbientColor.a));
+
         vec3 environmentSpecular = EnvBRDFApprox(specColor, roughness, ndv);
         vec3 environmentDiffuse = EnvBRDFApprox( diffColor * (1.0 - roughness), 1.0, ndv);
 
-        return hdrCube * environmentSpecular + hdrCubeD * environmentDiffuse;
+        return (hdrCube * environmentSpecular + hdrCubeD * environmentDiffuse) * brightness;
         //return ImportanceSampling(reflectVec, tangent, bitangent, wsNormal, toCamera, diffColor, specColor, roughness, reflectionCubeColor);
     }
 #endif

--- a/bin/CoreData/Shaders/GLSL/PBR.glsl
+++ b/bin/CoreData/Shaders/GLSL/PBR.glsl
@@ -18,7 +18,7 @@
         float ndl = clamp((dot(normal, lightVec)), M_EPSILON, 1.0);
         float ndv = clamp((dot(normal, toCamera)), M_EPSILON, 1.0);
 
-        vec3 diffuseFactor = Diffuse(diffColor, roughness * roughness, ndv, ndl, vdh);
+        vec3 diffuseFactor = Diffuse(diffColor, roughness, ndv, ndl, vdh);
         vec3 specularFactor = vec3(0.0, 0.0, 0.0);
 
         #ifdef SPECULAR

--- a/bin/CoreData/Shaders/GLSL/PBRDeferred.glsl
+++ b/bin/CoreData/Shaders/GLSL/PBRDeferred.glsl
@@ -76,7 +76,7 @@ void PS()
     // Position acquired via near/far ray is relative to camera. Bring position to world space
     vec3 eyeVec = -worldPos;
     worldPos += cCameraPosPS;
-    
+
     vec3 normal = normalInput.rgb;
     float roughness = length(normal);
     normal = normalize(normal);
@@ -112,6 +112,6 @@ void PS()
     vec3 BRDF = GetBRDF(lightDir, lightVec, toCamera, normal, roughness, albedoInput.rgb, specColor);
 
     gl_FragColor.a = 1.0;
-    gl_FragColor.rgb = pow(BRDF * lightColor * (atten * shadow * ndl) / M_PI, vec3(1.0 / 2.2));
+    gl_FragColor.rgb = BRDF * lightColor * (atten * shadow * ndl) / M_PI;
 
 }

--- a/bin/CoreData/Shaders/GLSL/PBRLitSolid.glsl
+++ b/bin/CoreData/Shaders/GLSL/PBRLitSolid.glsl
@@ -26,7 +26,7 @@ varying vec4 vWorldPos;
             varying vec4 vShadowPos[NUMCASCADES];
         #else
             varying highp vec4 vShadowPos[NUMCASCADES];
-        #endif 
+        #endif
     #endif
     #ifdef SPOTLIGHT
         varying vec4 vSpotPos;
@@ -189,7 +189,6 @@ void PS()
         vec3 BRDF = GetBRDF(lightDir, lightVec, toCamera, normal, roughness, diffColor.rgb, specColor);
 
         finalColor.rgb = BRDF * lightColor * (atten * shadow * ndl) / M_PI;
-        finalColor.rgb = pow(finalColor.rgb, vec3(1.0/ 2.2));
 
         #ifdef AMBIENT
             finalColor += cAmbientColor * diffColor.rgb;

--- a/bin/CoreData/Shaders/GLSL/Skybox.glsl
+++ b/bin/CoreData/Shaders/GLSL/Skybox.glsl
@@ -15,5 +15,9 @@ void VS()
 
 void PS()
 {
-    gl_FragColor = cMatDiffColor * textureCube(sDiffCubeMap, vTexCoord);
+    vec4 sky = cMatDiffColor * textureCube(sDiffCubeMap, vTexCoord);
+    #ifdef HDRSCALE
+        sky = mix(sky, pow(sky + 0.25, vec4(6.0)), max(cAmbientColor.a, 0.0));
+    #endif
+    gl_FragColor = sky;
 }

--- a/bin/CoreData/Shaders/GLSL/Skybox.glsl
+++ b/bin/CoreData/Shaders/GLSL/Skybox.glsl
@@ -17,7 +17,7 @@ void PS()
 {
     vec4 sky = cMatDiffColor * textureCube(sDiffCubeMap, vTexCoord);
     #ifdef HDRSCALE
-        sky = mix(sky, pow(sky + 0.25, vec4(6.0)), max(cAmbientColor.a, 0.0));
+        sky = pow(sky + clamp((cAmbientColor.a - 1.0) * 0.1, 0.0, 0.25), max(vec4(cAmbientColor.a), 1.0)) * clamp(cAmbientColor.a, 0.0, 1.0);
     #endif
     gl_FragColor = sky;
 }

--- a/bin/CoreData/Shaders/GLSL/Uniforms.glsl
+++ b/bin/CoreData/Shaders/GLSL/Uniforms.glsl
@@ -52,7 +52,7 @@ uniform mat4 cZone;
     precision mediump float;
 #endif
 
-uniform vec3 cAmbientColor;
+uniform vec4 cAmbientColor;
 uniform vec3 cCameraPosPS;
 uniform float cDeltaTimePS;
 uniform vec4 cDepthReconstruct;
@@ -171,7 +171,7 @@ uniform CameraPS
 
 uniform ZonePS
 {
-    vec3 cAmbientColor;
+    vec4 cAmbientColor;
     vec4 cFogParams;
     vec3 cFogColor;
 };

--- a/bin/CoreData/Shaders/HLSL/IBL.hlsl
+++ b/bin/CoreData/Shaders/HLSL/IBL.hlsl
@@ -257,16 +257,19 @@
 
         const float mipSelect = roughness  * 9.0;
 
-
         float3 cube = SampleCubeLOD(ZoneCubeMap, float4(reflectVec, mipSelect)).rgb;
         float3 cubeD = SampleCubeLOD(ZoneCubeMap, float4(reflectVec, 9.0)).rgb;
         // Fake the HDR texture
-        float3 hdrCube = lerp(cube, pow(cube + 0.25, 6.0), max(cAmbientColor.a, 0.0));
-        float3 hdrCubeD = lerp(cubeD, pow(cubeD + 0.25, 3.0), max(cAmbientColor.a, 0.0));
+        float brightness = clamp(cAmbientColor.a, 0.0, 1.0);
+        float darknessCutoff = clamp((cAmbientColor.a - 1.0) * 0.1, 0.0, 0.25);
+
+        float3 hdrCube = pow(cube + darknessCutoff, max(1.0, cAmbientColor.a));
+        float3 hdrCubeD = pow(cubeD + darknessCutoff, max(1.0, cAmbientColor.a));
+
         const float3 environmentSpecular = EnvBRDFApprox(specColor, roughness, ndv);
         const float3 environmentDiffuse = EnvBRDFApprox(diffColor * (1.0 - roughness), 1.0, ndv);
 
-        return hdrCube * environmentSpecular + hdrCubeD * environmentDiffuse;
+        return (hdrCube * environmentSpecular + hdrCubeD * environmentDiffuse) * brightness;
         //return ImportanceSampling(reflectVec, tangent, bitangent, wsNormal, toCamera, diffColor, specColor, roughness, reflectionCubeColor);
     }
 #endif

--- a/bin/CoreData/Shaders/HLSL/IBL.hlsl
+++ b/bin/CoreData/Shaders/HLSL/IBL.hlsl
@@ -258,13 +258,13 @@
         const float mipSelect = roughness  * 9.0;
 
         float3 cube = SampleCubeLOD(ZoneCubeMap, float4(reflectVec, mipSelect)).rgb;
-        float3 cubeD = SampleCubeLOD(ZoneCubeMap, float4(reflectVec, 9.0)).rgb;
+        float3 cubeD = SampleCubeLOD(ZoneCubeMap, float4(wsNormal, 9.0)).rgb;
         // Fake the HDR texture
         float brightness = clamp(cAmbientColor.a, 0.0, 1.0);
         float darknessCutoff = clamp((cAmbientColor.a - 1.0) * 0.1, 0.0, 0.25);
 
         float3 hdrCube = pow(cube + darknessCutoff, max(1.0, cAmbientColor.a));
-        float3 hdrCubeD = pow(cubeD + darknessCutoff, max(1.0, cAmbientColor.a));
+        float3 hdrCubeD = pow(cubeD + darknessCutoff, max(1.0, cAmbientColor.a * 0.5));
 
         const float3 environmentSpecular = EnvBRDFApprox(specColor, roughness, ndv);
         const float3 environmentDiffuse = EnvBRDFApprox(diffColor * (1.0 - roughness), 1.0, ndv);

--- a/bin/CoreData/Shaders/HLSL/IBL.hlsl
+++ b/bin/CoreData/Shaders/HLSL/IBL.hlsl
@@ -254,14 +254,19 @@
     {
         reflectVec = GetSpecularDominantDir(wsNormal, reflectVec, roughness);
         const float ndv = saturate(dot(-toCamera, wsNormal));
-        
-        const float mipSelect = roughness  * 9;
+
+        const float mipSelect = roughness  * 9.0;
+
 
         float3 cube = SampleCubeLOD(ZoneCubeMap, float4(reflectVec, mipSelect)).rgb;
+        float3 cubeD = SampleCubeLOD(ZoneCubeMap, float4(reflectVec, 9.0)).rgb;
+        // Fake the HDR texture
+        float3 hdrCube = lerp(cube, pow(cube + 0.25, 6.0), max(cAmbientColor.a, 0.0));
+        float3 hdrCubeD = lerp(cubeD, pow(cubeD + 0.25, 3.0), max(cAmbientColor.a, 0.0));
         const float3 environmentSpecular = EnvBRDFApprox(specColor, roughness, ndv);
-        const float3 environmentDiffuse = EnvBRDFApprox(diffColor, roughness, ndv);
+        const float3 environmentDiffuse = EnvBRDFApprox(diffColor * (1.0 - roughness), 1.0, ndv);
 
-        return cube * environmentSpecular + environmentDiffuse / M_PI;
+        return hdrCube * environmentSpecular + hdrCubeD * environmentDiffuse;
         //return ImportanceSampling(reflectVec, tangent, bitangent, wsNormal, toCamera, diffColor, specColor, roughness, reflectionCubeColor);
     }
 #endif

--- a/bin/CoreData/Shaders/HLSL/PBR.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBR.hlsl
@@ -18,7 +18,7 @@
         const float ndl = clamp((dot(normal, lightVec)), M_EPSILON, 1.0);
         const float ndv = clamp((dot(normal, toCamera)), M_EPSILON, 1.0);
 
-        const float3 diffuseFactor = Diffuse(diffColor, roughness * roughness, ndv, ndl, vdh);
+        const float3 diffuseFactor = Diffuse(diffColor, roughness, ndv, ndl, vdh);
         float3 specularFactor = 0;
 
         #ifdef SPECULAR

--- a/bin/CoreData/Shaders/HLSL/PBRDeferred.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBRDeferred.hlsl
@@ -116,5 +116,5 @@ void PS(
     float3 BRDF = GetBRDF(lightDir, lightVec, toCamera, normal, roughness, albedoInput.rgb, specColor);
 
     oColor.a = 1;
-    oColor.rgb  = pow(BRDF * lightColor * shadow * atten * ndl / M_PI, 1.0 / 2.2);
+    oColor.rgb  = BRDF * lightColor * shadow * atten * ndl / M_PI;
 }

--- a/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
@@ -25,7 +25,7 @@ void VS(float4 iPos : POSITION,
         float4 iTangent : TANGENT,
     #endif
     #ifdef SKINNED
-        float4 iBlendWeights : BLENDWEIGHT, 
+        float4 iBlendWeights : BLENDWEIGHT,
         int4 iBlendIndices : BLENDINDICES,
     #endif
     #ifdef INSTANCED
@@ -272,9 +272,6 @@ void PS(
 
         float3 BRDF = GetBRDF(lightDir, lightVec, toCamera, normal, roughness, diffColor.rgb, specColor);
         finalColor.rgb = BRDF * lightColor * (atten * shadow * ndl) / M_PI;
-
-        // Convert to SRGB
-        finalColor.rgb = pow(finalColor.rgb, 1.0 / 2.2);
 
         #ifdef AMBIENT
             finalColor += cAmbientColor * diffColor.rgb;

--- a/bin/CoreData/Shaders/HLSL/Skybox.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Skybox.hlsl
@@ -9,7 +9,7 @@ void VS(float4 iPos : POSITION,
     float4x3 modelMatrix = iModelMatrix;
     float3 worldPos = GetWorldPos(modelMatrix);
     oPos = GetClipPos(worldPos);
-    
+
     oPos.z = oPos.w;
     oTexCoord = iPos.xyz;
 }
@@ -17,5 +17,9 @@ void VS(float4 iPos : POSITION,
 void PS(float3 iTexCoord : TEXCOORD0,
     out float4 oColor : OUTCOLOR0)
 {
-    oColor = cMatDiffColor * SampleCube(DiffCubeMap, iTexCoord);
+    float4 sky = cMatDiffColor * SampleCube(DiffCubeMap, iTexCoord);
+    #ifdef HDRSCALE
+        sky = lerp(sky, pow(sky + 0.25, 6.0), max(cAmbientColor.a, 0.0));
+    #endif
+    oColor = sky;
 }

--- a/bin/CoreData/Shaders/HLSL/Skybox.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Skybox.hlsl
@@ -19,7 +19,7 @@ void PS(float3 iTexCoord : TEXCOORD0,
 {
     float4 sky = cMatDiffColor * SampleCube(DiffCubeMap, iTexCoord);
     #ifdef HDRSCALE
-        sky = lerp(sky, pow(sky + 0.25, 6.0), max(cAmbientColor.a, 0.0));
+        sky = pow(sky + clamp((cAmbientColor.a - 1.0) * 0.1, 0.0, 0.25), max(cAmbientColor.a, 1.0)) * clamp(cAmbientColor.a, 0.0, 1.0);
     #endif
     oColor = sky;
 }

--- a/bin/CoreData/Shaders/HLSL/Uniforms.hlsl
+++ b/bin/CoreData/Shaders/HLSL/Uniforms.hlsl
@@ -41,7 +41,7 @@ uniform float4x3 cZone;
 #ifdef COMPILEPS
 
 // Pixel shader uniforms
-uniform float3 cAmbientColor;
+uniform float4 cAmbientColor;
 uniform float3 cCameraPosPS;
 uniform float cDeltaTimePS;
 uniform float4 cDepthReconstruct;
@@ -58,7 +58,7 @@ uniform float3 cMatEmissiveColor;
 uniform float3 cMatEnvMapColor;
 uniform float4 cMatSpecColor;
 #ifdef PBR
-    uniform float cRoughnessPS; 
+    uniform float cRoughnessPS;
     uniform float cMetallicPS;
 #endif
 uniform float cNearClipPS;
@@ -160,7 +160,7 @@ cbuffer CameraPS : register(b1)
 
 cbuffer ZonePS : register(b2)
 {
-    float3 cAmbientColor;
+    float4 cAmbientColor;
     float4 cFogParams;
     float3 cFogColor;
 }
@@ -188,7 +188,7 @@ cbuffer MaterialPS : register(b4)
     float3 cMatEnvMapColor;
     float4 cMatSpecColor;
     #ifdef PBR
-        float cRoughnessPS; 
+        float cRoughnessPS;
         float cMetallicPS;
     #endif
 }

--- a/bin/CoreData/Techniques/DiffSkyboxHDRScale.xml
+++ b/bin/CoreData/Techniques/DiffSkyboxHDRScale.xml
@@ -1,0 +1,3 @@
+<technique vs="Skybox" ps="Skybox" psdefines="HDRSCALE">
+    <pass name="postopaque" depthwrite="false" />
+</technique>

--- a/bin/Data/Scenes/PBRExample.xml
+++ b/bin/Data/Scenes/PBRExample.xml
@@ -7,8 +7,8 @@
 	<attribute name="Elapsed Time" value="36.5594" />
 	<attribute name="Next Replicated Node ID" value="216" />
 	<attribute name="Next Replicated Component ID" value="235" />
-	<attribute name="Next Local Node ID" value="16777263" />
-	<attribute name="Next Local Component ID" value="16777757" />
+	<attribute name="Next Local Node ID" value="16777264" />
+	<attribute name="Next Local Component ID" value="16777769" />
 	<attribute name="Variables" />
 	<attribute name="Variable Names" value="" />
 	<component type="Octree" id="1" />
@@ -1135,7 +1135,7 @@
 				<attribute name="Variables" />
 				<component type="Light" id="4">
 					<attribute name="Light Type" value="Directional" />
-					<attribute name="Brightness Multiplier" value="2" />
+					<attribute name="Brightness Multiplier" value="8" />
 					<attribute name="Cast Shadows" value="true" />
 					<attribute name="CSM Splits" value="10 20 30 40" />
 				</component>

--- a/bin/Data/Scenes/PBRExample.xml
+++ b/bin/Data/Scenes/PBRExample.xml
@@ -7,8 +7,8 @@
 	<attribute name="Elapsed Time" value="36.5594" />
 	<attribute name="Next Replicated Node ID" value="216" />
 	<attribute name="Next Replicated Component ID" value="235" />
-	<attribute name="Next Local Node ID" value="16777257" />
-	<attribute name="Next Local Component ID" value="16777685" />
+	<attribute name="Next Local Node ID" value="16777262" />
+	<attribute name="Next Local Component ID" value="16777745" />
 	<attribute name="Variables" />
 	<attribute name="Variable Names" value="" />
 	<component type="Octree" id="1" />
@@ -93,7 +93,7 @@
 			<attribute name="Is Enabled" value="true" />
 			<attribute name="Name" value="Box" />
 			<attribute name="Tags" />
-			<attribute name="Position" value="1.16697 1.83612 -14.1164" />
+			<attribute name="Position" value="1.16697 1.83612 -13.6164" />
 			<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
 			<attribute name="Scale" value="3 3 1" />
 			<attribute name="Variables" />
@@ -121,7 +121,7 @@
 			<attribute name="Is Enabled" value="true" />
 			<attribute name="Name" value="Box" />
 			<attribute name="Tags" />
-			<attribute name="Position" value="-4.33303 1.83612 -14.1164" />
+			<attribute name="Position" value="-4.33303 1.83612 -13.6164" />
 			<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
 			<attribute name="Scale" value="3 3 1" />
 			<attribute name="Variables" />
@@ -149,7 +149,7 @@
 			<attribute name="Is Enabled" value="true" />
 			<attribute name="Name" value="Box" />
 			<attribute name="Tags" />
-			<attribute name="Position" value="-1.33303 1.83612 -14.1164" />
+			<attribute name="Position" value="-1.33303 1.83612 -13.6164" />
 			<attribute name="Rotation" value="2.68221e-07 -2.68221e-07 0.707107 0.707107" />
 			<attribute name="Scale" value="3 3 1" />
 			<attribute name="Variables" />
@@ -658,21 +658,6 @@
 			</component>
 		</node>
 	</node>
-	<node id="11">
-		<attribute name="Is Enabled" value="true" />
-		<attribute name="Name" value="Zone" />
-		<attribute name="Tags" />
-		<attribute name="Position" value="-1.58774 3.71769 -0.0921001" />
-		<attribute name="Rotation" value="1 0 0 0" />
-		<attribute name="Scale" value="1 1 1" />
-		<attribute name="Variables" />
-		<component type="Zone" id="11">
-			<attribute name="Bounding Box Min" value="-1000 -1000 -1000" />
-			<attribute name="Bounding Box Max" value="1000 1000 1000" />
-			<attribute name="Ambient Color" value="0 0 0 1" />
-			<attribute name="Zone Texture" value="TextureCube;Textures/Skybox2.xml" />
-		</component>
-	</node>
 	<node id="12">
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="Sky" />
@@ -865,22 +850,6 @@
 			</component>
 		</node>
 	</node>
-	<node id="127">
-		<attribute name="Is Enabled" value="true" />
-		<attribute name="Name" value="Zone" />
-		<attribute name="Tags" />
-		<attribute name="Position" value="-1.58774 3.71769 -11.0921" />
-		<attribute name="Rotation" value="1 0 0 0" />
-		<attribute name="Scale" value="1 1 1" />
-		<attribute name="Variables" />
-		<component type="Zone" id="137">
-			<attribute name="Bounding Box Min" value="-2.9 -1.52 -3.88" />
-			<attribute name="Bounding Box Max" value="3.9 1.52 4.87" />
-			<attribute name="Ambient Color" value="0 0 0 1" />
-			<attribute name="Priority" value="1" />
-			<attribute name="Zone Texture" value="TextureCube;Textures/Skybox2.xml" />
-		</component>
-	</node>
 	<node id="136">
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="Text" />
@@ -903,6 +872,20 @@
 				<attribute name="Text" value="Low Roughness" />
 				<attribute name="Width" value="134" />
 			</component>
+			<node id="163">
+				<attribute name="Is Enabled" value="true" />
+				<attribute name="Name" value="Sphere" />
+				<attribute name="Tags" />
+				<attribute name="Position" value="0.39605 -5.31091 -4.64596" />
+				<attribute name="Rotation" value="0.653281 -0.270598 -0.653282 0.270598" />
+				<attribute name="Scale" value="0.999999 1 0.999999" />
+				<attribute name="Variables" />
+				<component type="StaticModel" id="182">
+					<attribute name="Model" value="Model;Models/Sphere.mdl" />
+					<attribute name="Material" value="Material;Materials/PBR/Roughness5.xml" />
+					<attribute name="Cast Shadows" value="true" />
+				</component>
+			</node>
 		</node>
 		<node id="138">
 			<attribute name="Is Enabled" value="true" />
@@ -975,8 +958,8 @@
 			<component type="Text3D" id="215">
 				<attribute name="Font" value="Font;Fonts/BlueHighway.ttf" />
 				<attribute name="Font Size" value="15" />
-				<attribute name="Text" value="None Metallic" />
-				<attribute name="Width" value="116" />
+				<attribute name="Text" value="Non-Metallic" />
+				<attribute name="Width" value="104" />
 			</component>
 		</node>
 	</node>
@@ -1007,34 +990,20 @@
 			<attribute name="Material" value="Material;Materials/PBR/Roughness10.xml" />
 			<attribute name="Cast Shadows" value="true" />
 		</component>
-	</node>
-	<node id="162">
-		<attribute name="Is Enabled" value="true" />
-		<attribute name="Name" value="Sphere" />
-		<attribute name="Tags" />
-		<attribute name="Position" value="-4.90273 2.84736 0.993734" />
-		<attribute name="Rotation" value="1 0 0 0" />
-		<attribute name="Scale" value="1 1 1" />
-		<attribute name="Variables" />
-		<component type="StaticModel" id="181">
-			<attribute name="Model" value="Model;Models/Sphere.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Roughness3.xml" />
-			<attribute name="Cast Shadows" value="true" />
-		</component>
-	</node>
-	<node id="163">
-		<attribute name="Is Enabled" value="true" />
-		<attribute name="Name" value="Sphere" />
-		<attribute name="Tags" />
-		<attribute name="Position" value="-4.90273 2.84736 -0.506262" />
-		<attribute name="Rotation" value="1 0 0 0" />
-		<attribute name="Scale" value="1 1 1" />
-		<attribute name="Variables" />
-		<component type="StaticModel" id="182">
-			<attribute name="Model" value="Model;Models/Sphere.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Roughness5.xml" />
-			<attribute name="Cast Shadows" value="true" />
-		</component>
+		<node id="162">
+			<attribute name="Is Enabled" value="true" />
+			<attribute name="Name" value="Sphere" />
+			<attribute name="Tags" />
+			<attribute name="Position" value="0 0 4.49999" />
+			<attribute name="Rotation" value="1 0 0 0" />
+			<attribute name="Scale" value="1 1 1" />
+			<attribute name="Variables" />
+			<component type="StaticModel" id="181">
+				<attribute name="Model" value="Model;Models/Sphere.mdl" />
+				<attribute name="Material" value="Material;Materials/PBR/Roughness3.xml" />
+				<attribute name="Cast Shadows" value="true" />
+			</component>
+		</node>
 	</node>
 	<node id="164">
 		<attribute name="Is Enabled" value="true" />
@@ -1160,9 +1129,9 @@
 				<attribute name="Is Enabled" value="true" />
 				<attribute name="Name" value="Directional" />
 				<attribute name="Tags" />
-				<attribute name="Position" value="0 0 0" />
-				<attribute name="Rotation" value="0.707107 0.707107 0 0" />
-				<attribute name="Scale" value="1 1 1" />
+				<attribute name="Position" value="-4.76837e-07 0 -9.53674e-07" />
+				<attribute name="Rotation" value="0.707102 0.707102 0.0016455 0.000548521" />
+				<attribute name="Scale" value="1.00001 1 1.00004" />
 				<attribute name="Variables" />
 				<component type="Light" id="4">
 					<attribute name="Light Type" value="Directional" />
@@ -1222,7 +1191,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="195">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Concrete.xml" />
 		</component>
 	</node>
 	<node id="177">
@@ -1235,7 +1204,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="196">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Concrete.xml" />
 		</component>
 	</node>
 	<node id="178">
@@ -1248,7 +1217,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="197">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Concrete.xml" />
 		</component>
 	</node>
 	<node id="179">
@@ -1261,7 +1230,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="198">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Concrete.xml" />
 		</component>
 	</node>
 	<node id="180">
@@ -1274,7 +1243,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="199">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Concrete.xml" />
 		</component>
 	</node>
 	<node id="181">
@@ -1287,7 +1256,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="200">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Concrete.xml" />
 		</component>
 	</node>
 	<node id="182">
@@ -1300,7 +1269,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="201">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Concrete.xml" />
 		</component>
 	</node>
 	<node id="183">
@@ -1313,7 +1282,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="202">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Concrete.xml" />
 		</component>
 	</node>
 	<node id="184">
@@ -1326,7 +1295,7 @@
 		<attribute name="Variables" />
 		<component type="StaticModel" id="203">
 			<attribute name="Model" value="Model;Models/Plane.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Check.xml" />
+			<attribute name="Material" value="Material;Materials/PBR/Concrete.xml" />
 		</component>
 	</node>
 	<node id="185">
@@ -1427,20 +1396,6 @@
 			<attribute name="Cast Shadows" value="true" />
 		</component>
 	</node>
-	<node id="201">
-		<attribute name="Is Enabled" value="true" />
-		<attribute name="Name" value="Sphere" />
-		<attribute name="Tags" />
-		<attribute name="Position" value="-4.90273 2.84736 -8.24909" />
-		<attribute name="Rotation" value="1 0 0 0" />
-		<attribute name="Scale" value="1 1 1" />
-		<attribute name="Variables" />
-		<component type="StaticModel" id="220">
-			<attribute name="Model" value="Model;Models/Sphere.mdl" />
-			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
-			<attribute name="Cast Shadows" value="true" />
-		</component>
-	</node>
 	<node id="202">
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="Sphere" />
@@ -1483,31 +1438,19 @@
 			<attribute name="Cast Shadows" value="true" />
 		</component>
 	</node>
-	<node id="205">
-		<attribute name="Is Enabled" value="true" />
-		<attribute name="Name" value="" />
-		<attribute name="Tags" />
-		<attribute name="Position" value="-2.09537 6.21456 0.703436" />
-		<attribute name="Rotation" value="1 0 0 0" />
-		<attribute name="Scale" value="1 1 1" />
-		<attribute name="Variables" />
-		<component type="Light" id="224">
-			<attribute name="Specular Intensity" value="0" />
-			<attribute name="Brightness Multiplier" value="0.3" />
-			<attribute name="Light Shape Texture" value="TextureCube;" />
-		</component>
-	</node>
 	<node id="206">
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="" />
 		<attribute name="Tags" />
-		<attribute name="Position" value="-2.09537 6.21456 -12.7966" />
+		<attribute name="Position" value="-2.59537 6.21456 -10.2966" />
 		<attribute name="Rotation" value="1 0 0 0" />
 		<attribute name="Scale" value="1 1 1" />
 		<attribute name="Variables" />
 		<component type="Light" id="225">
-			<attribute name="Brightness Multiplier" value="0.2" />
+			<attribute name="Brightness Multiplier" value="2" />
+			<attribute name="Range" value="10.69" />
 			<attribute name="Light Shape Texture" value="TextureCube;" />
+			<attribute name="Cast Shadows" value="true" />
 		</component>
 	</node>
 	<node id="207">
@@ -1523,6 +1466,20 @@
 			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
 			<attribute name="Cast Shadows" value="true" />
 		</component>
+		<node id="205">
+			<attribute name="Is Enabled" value="true" />
+			<attribute name="Name" value="" />
+			<attribute name="Tags" />
+			<attribute name="Position" value="1.75146 3.81505 10.4098" />
+			<attribute name="Rotation" value="1 0 0 0" />
+			<attribute name="Scale" value="1 1 1" />
+			<attribute name="Variables" />
+			<component type="Light" id="224">
+				<attribute name="Brightness Multiplier" value="2" />
+				<attribute name="Light Shape Texture" value="TextureCube;" />
+				<attribute name="Cast Shadows" value="true" />
+			</component>
+		</node>
 	</node>
 	<node id="208">
 		<attribute name="Is Enabled" value="true" />
@@ -1621,6 +1578,35 @@
 			<attribute name="Model" value="Model;Models/HoverBike.mdl" />
 			<attribute name="Material" value="Material;Materials/PBR/HoverBikeGlass.xml;Materials/PBR/HoverBikeHull.xml" />
 			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="201">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-4.90273 2.84736 -8.24909" />
+		<attribute name="Rotation" value="1 0 -3.97365e-07 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="220">
+			<attribute name="Model" value="Model;Models/Sphere.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="11">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Zone" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-1.58774 3.71769 -0.0921001" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="Zone" id="11">
+			<attribute name="Bounding Box Min" value="-1000 -1000 -1000" />
+			<attribute name="Bounding Box Max" value="1000 1000 1000" />
+			<attribute name="Ambient Color" value="0 0 0 1" />
+			<attribute name="Zone Texture" value="TextureCube;Textures/Skybox2.xml" />
 		</component>
 	</node>
 </scene>

--- a/bin/Data/Scenes/PBRExample.xml
+++ b/bin/Data/Scenes/PBRExample.xml
@@ -7,8 +7,8 @@
 	<attribute name="Elapsed Time" value="36.5594" />
 	<attribute name="Next Replicated Node ID" value="216" />
 	<attribute name="Next Replicated Component ID" value="235" />
-	<attribute name="Next Local Node ID" value="16777262" />
-	<attribute name="Next Local Component ID" value="16777745" />
+	<attribute name="Next Local Node ID" value="16777263" />
+	<attribute name="Next Local Component ID" value="16777757" />
 	<attribute name="Variables" />
 	<attribute name="Variable Names" value="" />
 	<component type="Octree" id="1" />
@@ -1605,7 +1605,7 @@
 		<component type="Zone" id="11">
 			<attribute name="Bounding Box Min" value="-1000 -1000 -1000" />
 			<attribute name="Bounding Box Max" value="1000 1000 1000" />
-			<attribute name="Ambient Color" value="0 0 0 1" />
+			<attribute name="Ambient Color" value="0 0 0 5" />
 			<attribute name="Zone Texture" value="TextureCube;Textures/Skybox2.xml" />
 		</component>
 	</node>

--- a/bin/Data/Scripts/42_PBRMaterials.as
+++ b/bin/Data/Scripts/42_PBRMaterials.as
@@ -68,6 +68,7 @@ void SetupViewport()
     RenderPath@ effectRenderPath = viewport.renderPath.Clone();
     effectRenderPath.Append(cache.GetResource("XMLFile", "PostProcess/BloomHDR.xml"));
     effectRenderPath.Append(cache.GetResource("XMLFile", "PostProcess/FXAA2.xml"));
+    effectRenderPath.Append(cache.GetResource("XMLFile", "PostProcess/GammaCorrection.xml"));
 
     viewport.renderPath = effectRenderPath;
 }


### PR DESCRIPTION
I made some minor tweaks.

I believe many see the gamma issue as a over-bright vs darks issue, where the gamma correction I applied before appears as over-bright and the uncorrected version appears better due to richer darks. The main reason for this is that the IBL isn't using HDR textures (and urho doesn't load hdr texture information atm), so for now I've added a hdr-scaling to add some fake hdr amount. You can change the zone ambient colour alpha to see the difference (1 is how it was before, >1 fakes hdr, <1 lets you dim the ibl).

As far as viewing in the editor, the simplest way atm is to open the console and type graphics.sRGB = 1. Alternatively we could append the GammaCorrection post-process to the renderpath xmls, but that won't work for forward atm. Having an option in the preferences menu makes the most sense.