### PR TITLE
Tweaks2

### DIFF
--- a/bin/Autoload/LargeData/Materials/PBR/HighRoughMetallic3.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/HighRoughMetallic3.xml
@@ -7,8 +7,8 @@
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
-	<parameter name="RoughnessPS" value="0.7" />
-	<parameter name="MetallicPS" value="0.3" />
+	<parameter name="RoughnessPS" value="0.75" />
+	<parameter name="MetallicPS" value="0.25" />
 	<cull value="ccw" />
 	<shadowcull value="ccw" />
 	<fill value="solid" />

--- a/bin/Autoload/LargeData/Materials/PBR/HighRoughMetallic7.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/HighRoughMetallic7.xml
@@ -7,8 +7,8 @@
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
-	<parameter name="RoughnessPS" value="0.7" />
-	<parameter name="MetallicPS" value="0.7" />
+	<parameter name="RoughnessPS" value="0.75" />
+	<parameter name="MetallicPS" value="0.75" />
 	<cull value="ccw" />
 	<shadowcull value="ccw" />
 	<fill value="solid" />

--- a/bin/Autoload/LargeData/Materials/PBR/Metallic3.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Metallic3.xml
@@ -8,7 +8,7 @@
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
 	<parameter name="RoughnessPS" value="0" />
-	<parameter name="MetallicPS" value="0.3" />
+	<parameter name="MetallicPS" value="0.25" />
 	<cull value="ccw" />
 	<shadowcull value="ccw" />
 	<fill value="solid" />

--- a/bin/Autoload/LargeData/Materials/PBR/Metallic7.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Metallic7.xml
@@ -8,7 +8,7 @@
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
 	<parameter name="RoughnessPS" value="0" />
-	<parameter name="MetallicPS" value="0.7" />
+	<parameter name="MetallicPS" value="0.75" />
 	<cull value="ccw" />
 	<shadowcull value="ccw" />
 	<fill value="solid" />

--- a/bin/Autoload/LargeData/Materials/PBR/MetallicRough7.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/MetallicRough7.xml
@@ -7,7 +7,7 @@
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
-	<parameter name="RoughnessPS" value="0.7" />
+	<parameter name="RoughnessPS" value="0.75" />
 	<parameter name="MetallicPS" value="1" />
 	<cull value="ccw" />
 	<shadowcull value="ccw" />

--- a/bin/Autoload/LargeData/Materials/PBR/Roughness3.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Roughness3.xml
@@ -7,7 +7,7 @@
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
-	<parameter name="RoughnessPS" value="0.3" />
+	<parameter name="RoughnessPS" value="0.25" />
 	<parameter name="MetallicPS" value="0" />
 	<cull value="ccw" />
 	<shadowcull value="ccw" />

--- a/bin/Autoload/LargeData/Materials/PBR/Roughness7.xml
+++ b/bin/Autoload/LargeData/Materials/PBR/Roughness7.xml
@@ -7,7 +7,7 @@
 	<parameter name="MatEmissiveColor" value="0 0 0" />
 	<parameter name="MatEnvMapColor" value="1 1 1" />
 	<parameter name="MatSpecColor" value="1 1 1 1" />
-	<parameter name="RoughnessPS" value="0.7" />
+	<parameter name="RoughnessPS" value="0.75" />
 	<parameter name="MetallicPS" value="0" />
 	<cull value="ccw" />
 	<shadowcull value="ccw" />

--- a/bin/Autoload/LargeData/Textures/Skybox2.xml
+++ b/bin/Autoload/LargeData/Textures/Skybox2.xml
@@ -8,4 +8,5 @@
     <face name="output_pmrem_negz.dds" />
     <address coord="uv" mode="clamp" />
     <mipmap enable="true" />
+    <filter mode="trilinear" />
 </cubemap>

--- a/bin/CoreData/Shaders/GLSL/PBR.glsl
+++ b/bin/CoreData/Shaders/GLSL/PBR.glsl
@@ -28,6 +28,6 @@
             specularFactor = fresnelTerm * distTerm * visTerm  / M_PI;
         #endif
 
-        return diffuseFactor * diffColor.rgb + specularFactor;
+        return diffuseFactor + specularFactor;
 	}
 #endif

--- a/bin/CoreData/Shaders/GLSL/PBRDeferred.glsl
+++ b/bin/CoreData/Shaders/GLSL/PBRDeferred.glsl
@@ -112,6 +112,6 @@ void PS()
     vec3 BRDF = GetBRDF(lightDir, lightVec, toCamera, normal, roughness, albedoInput.rgb, specColor);
 
     gl_FragColor.a = 1.0;
-    gl_FragColor.rgb = BRDF * lightColor * (atten * shadow * ndl) / M_PI;
+    gl_FragColor.rgb = BRDF * lightColor * (atten * shadow) / M_PI;
 
 }

--- a/bin/CoreData/Shaders/GLSL/PBRLitSolid.glsl
+++ b/bin/CoreData/Shaders/GLSL/PBRLitSolid.glsl
@@ -129,12 +129,17 @@ void PS()
     #ifdef METALLIC
         vec4 roughMetalSrc = texture2D(sSpecMap, vTexCoord.xy);
 
-        float roughness = clamp(pow(roughMetalSrc.r + cRoughnessPS, 2.0), ROUGHNESS_FLOOR, 1.0);
-        float metalness = clamp(roughMetalSrc.g + cMetallicPS, METALNESS_FLOOR, 1.0);
+        float roughness = roughMetalSrc.r + cRoughnessPS;
+        float metalness = roughMetalSrc.g + cMetallicPS;
     #else
-        float roughness = clamp(cRoughnessPS, 0.03, 1.0);
-        float metalness = clamp(cMetallicPS, METALNESS_FLOOR, 1.0);
+        float roughness = cRoughnessPS;
+        float metalness = cMetallicPS;
     #endif
+
+    roughness *= roughness;
+
+    roughness = clamp(roughness, ROUGHNESS_FLOOR, 1.0);
+    metalness = clamp(metalness, METALNESS_FLOOR, 1.0);
 
     vec3 specColor = mix(0.08 * cMatSpecColor.rgb, diffColor.rgb, metalness);
     diffColor.rgb = diffColor.rgb - diffColor.rgb * metalness;
@@ -167,7 +172,6 @@ void PS()
         vec3 lightDir;
         vec3 finalColor;
 
-        #line 200
         float atten = GetAtten(normal, vWorldPos.xyz, lightDir);
         float shadow = 1;
         #ifdef SHADOW
@@ -185,10 +189,9 @@ void PS()
         vec3 lightVec = normalize(lightDir);
         float ndl = clamp((dot(normal, lightVec)), M_EPSILON, 1.0);
 
-        #line 250
         vec3 BRDF = GetBRDF(lightDir, lightVec, toCamera, normal, roughness, diffColor.rgb, specColor);
 
-        finalColor.rgb = BRDF * lightColor * (atten * shadow * ndl) / M_PI;
+        finalColor.rgb = BRDF * lightColor * (atten * shadow) / M_PI;
 
         #ifdef AMBIENT
             finalColor += cAmbientColor * diffColor.rgb;

--- a/bin/CoreData/Shaders/HLSL/PBR.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBR.hlsl
@@ -29,6 +29,6 @@
             specularFactor = distTerm * visTerm * fresnelTerm / M_PI;
         #endif
 
-        return diffuseFactor * diffColor.rgb + specularFactor;
+        return diffuseFactor + specularFactor;
 	}
 #endif

--- a/bin/CoreData/Shaders/HLSL/PBRDeferred.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBRDeferred.hlsl
@@ -116,5 +116,5 @@ void PS(
     float3 BRDF = GetBRDF(lightDir, lightVec, toCamera, normal, roughness, albedoInput.rgb, specColor);
 
     oColor.a = 1;
-    oColor.rgb  = BRDF * lightColor * shadow * atten * ndl / M_PI;
+    oColor.rgb  = BRDF * lightColor * shadow * atten / M_PI;
 }

--- a/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
+++ b/bin/CoreData/Shaders/HLSL/PBRLitSolid.hlsl
@@ -207,14 +207,19 @@ void PS(
 
     // Get material specular albedo
     #ifdef METALLIC // METALNESS
-        const float4 roughMetalSrc = Sample2D(RoughMetalFresnel, iTexCoord.xy);
+        float4 roughMetalSrc = Sample2D(RoughMetalFresnel, iTexCoord.xy);
 
-        const float roughness = clamp(pow(roughMetalSrc.r + cRoughnessPS, 2.0), ROUGHNESS_FLOOR, 1.0);
-        const float metalness = clamp(roughMetalSrc.g + cMetallicPS, METALNESS_FLOOR, 1.0);
+        float roughness = roughMetalSrc.r + cRoughnessPS;
+        float metalness = roughMetalSrc.g + cMetallicPS;
     #else
-        const float roughness = clamp(pow(cRoughnessPS, 2.0), ROUGHNESS_FLOOR, 1.0);
-        const float metalness = clamp(cMetallicPS, METALNESS_FLOOR, 1.0);
+        float roughness = cRoughnessPS;
+        float metalness = cMetallicPS;
     #endif
+
+    roughness *= roughness;
+
+    roughness = clamp(roughness, ROUGHNESS_FLOOR, 1.0);
+    metalness = clamp(metalness, METALNESS_FLOOR, 1.0);
 
     float3 specColor = lerp(0.08 * cMatSpecColor.rgb, diffColor.rgb, metalness);
     specColor *= cMatSpecColor.rgb;
@@ -271,7 +276,7 @@ void PS(
 
 
         float3 BRDF = GetBRDF(lightDir, lightVec, toCamera, normal, roughness, diffColor.rgb, specColor);
-        finalColor.rgb = BRDF * lightColor * (atten * shadow * ndl) / M_PI;
+        finalColor.rgb = BRDF * lightColor * (atten * shadow) / M_PI;
 
         #ifdef AMBIENT
             finalColor += cAmbientColor * diffColor.rgb;

--- a/bin/Data/Scenes/PBRExample.xml
+++ b/bin/Data/Scenes/PBRExample.xml
@@ -5,10 +5,10 @@
 	<attribute name="Smoothing Constant" value="50" />
 	<attribute name="Snap Threshold" value="5" />
 	<attribute name="Elapsed Time" value="36.5594" />
-	<attribute name="Next Replicated Node ID" value="217" />
-	<attribute name="Next Replicated Component ID" value="236" />
-	<attribute name="Next Local Node ID" value="16777258" />
-	<attribute name="Next Local Component ID" value="16777697" />
+	<attribute name="Next Replicated Node ID" value="232" />
+	<attribute name="Next Replicated Component ID" value="251" />
+	<attribute name="Next Local Node ID" value="16777266" />
+	<attribute name="Next Local Component ID" value="16777793" />
 	<attribute name="Variables" />
 	<attribute name="Variable Names" value="" />
 	<component type="Octree" id="1" />
@@ -669,7 +669,7 @@
 		<component type="Zone" id="11">
 			<attribute name="Bounding Box Min" value="-1000 -1000 -1000" />
 			<attribute name="Bounding Box Max" value="1000 1000 1000" />
-			<attribute name="Ambient Color" value="0 0 0 1" />
+			<attribute name="Ambient Color" value="0 0 0 5" />
 			<attribute name="Zone Texture" value="TextureCube;Textures/Skybox2.xml" />
 		</component>
 	</node>
@@ -719,20 +719,6 @@
 			<component type="StaticModel" id="104">
 				<attribute name="Model" value="Model;Models/Sphere.mdl" />
 				<attribute name="Material" value="Material;Materials/PBR/MetallicRough3.xml" />
-				<attribute name="Cast Shadows" value="true" />
-			</component>
-		</node>
-		<node id="96">
-			<attribute name="Is Enabled" value="true" />
-			<attribute name="Name" value="Sphere" />
-			<attribute name="Tags" />
-			<attribute name="Position" value="-6.37848 3.29958 -0.506262" />
-			<attribute name="Rotation" value="1 0 0 0" />
-			<attribute name="Scale" value="1 1 1" />
-			<attribute name="Variables" />
-			<component type="StaticModel" id="105">
-				<attribute name="Model" value="Model;Models/Sphere.mdl" />
-				<attribute name="Material" value="Material;Materials/PBR/MetallicRough5.xml" />
 				<attribute name="Cast Shadows" value="true" />
 			</component>
 		</node>
@@ -864,22 +850,20 @@
 				<attribute name="Cast Shadows" value="true" />
 			</component>
 		</node>
-	</node>
-	<node id="127">
-		<attribute name="Is Enabled" value="true" />
-		<attribute name="Name" value="Zone" />
-		<attribute name="Tags" />
-		<attribute name="Position" value="-1.58774 3.71769 -11.0921" />
-		<attribute name="Rotation" value="1 0 0 0" />
-		<attribute name="Scale" value="1 1 1" />
-		<attribute name="Variables" />
-		<component type="Zone" id="137">
-			<attribute name="Bounding Box Min" value="-2.9 -1.52 -3.88" />
-			<attribute name="Bounding Box Max" value="3.9 1.52 4.87" />
-			<attribute name="Ambient Color" value="0 0 0 1" />
-			<attribute name="Priority" value="1" />
-			<attribute name="Zone Texture" value="TextureCube;Textures/Skybox2.xml" />
-		</component>
+		<node id="96">
+			<attribute name="Is Enabled" value="true" />
+			<attribute name="Name" value="Sphere" />
+			<attribute name="Tags" />
+			<attribute name="Position" value="-6.37848 3.29958 -0.506262" />
+			<attribute name="Rotation" value="1 0 0 0" />
+			<attribute name="Scale" value="1 1 1" />
+			<attribute name="Variables" />
+			<component type="StaticModel" id="105">
+				<attribute name="Model" value="Model;Models/Sphere.mdl" />
+				<attribute name="Material" value="Material;Materials/PBR/MetallicRough5.xml" />
+				<attribute name="Cast Shadows" value="true" />
+			</component>
+		</node>
 	</node>
 	<node id="136">
 		<attribute name="Is Enabled" value="true" />
@@ -1040,7 +1024,7 @@
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="Sphere" />
 		<attribute name="Tags" />
-		<attribute name="Position" value="-3.84683 2.39951 -12.7063" />
+		<attribute name="Position" value="-0.84683 2.39951 -12.7063" />
 		<attribute name="Rotation" value="1 0 0 0" />
 		<attribute name="Scale" value="1 1 1" />
 		<attribute name="Variables" />
@@ -1166,7 +1150,7 @@
 				<attribute name="Variables" />
 				<component type="Light" id="4">
 					<attribute name="Light Type" value="Directional" />
-					<attribute name="Brightness Multiplier" value="2" />
+					<attribute name="Brightness Multiplier" value="4" />
 					<attribute name="Cast Shadows" value="true" />
 					<attribute name="CSM Splits" value="10 20 30 40" />
 				</component>
@@ -1445,7 +1429,7 @@
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="Sphere" />
 		<attribute name="Tags" />
-		<attribute name="Position" value="-3.84683 2.39951 -8.24909" />
+		<attribute name="Position" value="-0.84683 2.39951 -8.24909" />
 		<attribute name="Rotation" value="1 0 0 0" />
 		<attribute name="Scale" value="1 1 1" />
 		<attribute name="Variables" />
@@ -1459,7 +1443,7 @@
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="Sphere" />
 		<attribute name="Tags" />
-		<attribute name="Position" value="-3.84683 2.39951 -6.70634" />
+		<attribute name="Position" value="-0.84683 2.39951 -6.70634" />
 		<attribute name="Rotation" value="1 0 0 0" />
 		<attribute name="Scale" value="1 1 1" />
 		<attribute name="Variables" />
@@ -1492,8 +1476,6 @@
 		<attribute name="Scale" value="1 1 1" />
 		<attribute name="Variables" />
 		<component type="Light" id="224">
-			<attribute name="Specular Intensity" value="0" />
-			<attribute name="Brightness Multiplier" value="0.3" />
 			<attribute name="Light Shape Texture" value="TextureCube;" />
 		</component>
 	</node>
@@ -1506,7 +1488,6 @@
 		<attribute name="Scale" value="1 1 1" />
 		<attribute name="Variables" />
 		<component type="Light" id="225">
-			<attribute name="Brightness Multiplier" value="0.2" />
 			<attribute name="Light Shape Texture" value="TextureCube;" />
 		</component>
 	</node>
@@ -1514,7 +1495,7 @@
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="Sphere" />
 		<attribute name="Tags" />
-		<attribute name="Position" value="-3.84683 2.39951 -9.70634" />
+		<attribute name="Position" value="-0.84683 2.39951 -9.70634" />
 		<attribute name="Rotation" value="1 0 0 0" />
 		<attribute name="Scale" value="1 1 1" />
 		<attribute name="Variables" />
@@ -1542,7 +1523,7 @@
 		<attribute name="Is Enabled" value="true" />
 		<attribute name="Name" value="Sphere" />
 		<attribute name="Tags" />
-		<attribute name="Position" value="-3.84683 2.39951 -11.2063" />
+		<attribute name="Position" value="-0.84683 2.39951 -11.2063" />
 		<attribute name="Rotation" value="1 0 0 0" />
 		<attribute name="Scale" value="1 1 1" />
 		<attribute name="Variables" />
@@ -1634,6 +1615,216 @@
 		<component type="StaticModel" id="235">
 			<attribute name="Model" value="Model;Models/Sphere.mdl" />
 			<attribute name="Material" value="Material;Materials/PBR/HighRoughMetallic10.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="217">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-3.84683 2.39951 -11.2063" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="236">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/DiamonPlate.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="218">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-2.84683 2.39951 -11.2063" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="237">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/DiamonPlate.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="219">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-1.84683 2.39951 -11.2063" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="238">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/DiamonPlate.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="220">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-3.84683 2.39951 -12.7063" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="239">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Lead.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="221">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-2.84683 2.39951 -12.7063" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="240">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Lead.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="222">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-1.84683 2.39951 -12.7063" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="241">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Lead.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="223">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-3.84683 2.39951 -8.24909" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="242">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="224">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-2.84683 2.39951 -8.24909" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="243">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="225">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-1.84683 2.39951 -8.24909" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="244">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Sand.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="226">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-3.84683 2.39951 -9.70634" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="245">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="227">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-2.84683 2.39951 -9.70634" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="246">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="228">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-1.84683 2.39951 -9.70634" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="247">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Mud.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="229">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-3.84683 2.39951 -6.70634" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="248">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Leather.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="230">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-2.84683 2.39951 -6.70634" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="249">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Leather.xml" />
+			<attribute name="Cast Shadows" value="true" />
+		</component>
+	</node>
+	<node id="231">
+		<attribute name="Is Enabled" value="true" />
+		<attribute name="Name" value="Sphere" />
+		<attribute name="Tags" />
+		<attribute name="Position" value="-1.84683 2.39951 -6.70634" />
+		<attribute name="Rotation" value="1 0 0 0" />
+		<attribute name="Scale" value="1 1 1" />
+		<attribute name="Variables" />
+		<component type="StaticModel" id="250">
+			<attribute name="Model" value="Model;Models/Plane.mdl" />
+			<attribute name="Material" value="Material;Materials/PBR/Leather.xml" />
 			<attribute name="Cast Shadows" value="true" />
 		</component>
 	</node>

--- a/bin/Data/Scripts/42_PBRMaterials.as
+++ b/bin/Data/Scripts/42_PBRMaterials.as
@@ -10,6 +10,7 @@
 Material@ dynamicMaterial;
 Text@ roughnessLabel;
 Text@ metallicLabel;
+Text@ ambientLabel;
 
 void Start()
 {
@@ -21,7 +22,7 @@ void Start()
 
     // Create the UI content and subscribe to UI events
     CreateUI();
-    
+
     CreateInstructions();
 
     // Setup the viewport for displaying the scene
@@ -52,7 +53,7 @@ void CreateScene()
     // Load scene content prepared in the editor (XML format). GetFile() returns an open file from the resource system
     // which scene.LoadXML() will read
     scene_.LoadXML(cache.GetFile("Scenes/PBRExample.xml"));
-    
+
     Node@ sphereWithDynamicMatNode = scene_.GetChild("SphereWithDynamicMat");
     StaticModel@ staticModel = sphereWithDynamicMatNode.GetComponent("StaticModel");
     dynamicMaterial = staticModel.materials[0];
@@ -90,7 +91,12 @@ void CreateUI()
     metallicLabel.SetFont(cache.GetResource("Font", "Fonts/Anonymous Pro.ttf"), 15);
     metallicLabel.SetPosition(370, 100);
     metallicLabel.textEffect = TE_SHADOW;
-    
+
+    ambientLabel = ui.root.CreateChild("Text");
+    ambientLabel.SetFont(cache.GetResource("Font", "Fonts/Anonymous Pro.ttf"), 15);
+    ambientLabel.SetPosition(370, 150);
+    ambientLabel.textEffect = TE_SHADOW;
+
     Slider@ roughnessSlider = ui.root.CreateChild("Slider");
     roughnessSlider.SetStyleAuto();
     roughnessSlider.SetPosition(50, 50);
@@ -98,7 +104,7 @@ void CreateUI()
     roughnessSlider.range = 1.0f; // 0 - 1 range
     SubscribeToEvent(roughnessSlider, "SliderChanged", "HandleRoughnessSliderChanged");
     roughnessSlider.value = 0.5f;
-    
+
     Slider@ metallicSlider = ui.root.CreateChild("Slider");
     metallicSlider.SetStyleAuto();
     metallicSlider.SetPosition(50, 100);
@@ -106,6 +112,14 @@ void CreateUI()
     metallicSlider.range = 1.0f; // 0 - 1 range
     SubscribeToEvent(metallicSlider, "SliderChanged", "HandleMetallicSliderChanged");
     metallicSlider.value = 0.5f;
+
+    Slider@ ambientSlider = ui.root.CreateChild("Slider");
+    ambientSlider.SetStyleAuto();
+    ambientSlider.SetPosition(50, 150);
+    ambientSlider.SetSize(300, 20);
+    ambientSlider.range = 10.0f; // 0 - 1 range
+    SubscribeToEvent(ambientSlider, "SliderChanged", "HandleAmbientSliderChanged");
+    ambientSlider.value = 5.0f;
 }
 
 void HandleRoughnessSliderChanged(StringHash eventType, VariantMap& eventData)
@@ -120,6 +134,16 @@ void HandleMetallicSliderChanged(StringHash eventType, VariantMap& eventData)
     float newValue = eventData["Value"].GetFloat();
     dynamicMaterial.shaderParameters["MetallicPS"] = newValue;
     metallicLabel.text = "Metallic: " + newValue;
+}
+
+void HandleAmbientSliderChanged(StringHash eventType, VariantMap& eventData)
+{
+    float newValue = eventData["Value"].GetFloat();
+    Node@ zoneNode = scene_.GetChild("Zone");
+    Zone@ zone = zoneNode.GetComponent("Zone");
+    Color col = Color(0.0, 0.0, 0.0, newValue);
+    zone.SetAttribute("Ambient Color", Variant(col));
+    ambientLabel.text = "Ambient HDR Scale: " + zone.ambientColor.a;
 }
 
 void SetupViewport()


### PR DESCRIPTION
> - Removed inconsistency with roughness input.
> - Switched to a different mip map selection method for the IBL.
> - Extended the angelscript PBR sample to include a slider for ambient HDR scaling.
> - Removed an extra diffuse factor in lighting output.

The major visual differences are the diffuse factor change (which was causing diffuse to burn out) and the mip selection. The mip selection change brings the appearance of the IBL closer to the direct lighting (eg, surfaces that appear rough in direct light should also appear rough in the IBL).